### PR TITLE
Replace `gcr.io` `kube-rbac-proxy` image

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -16,9 +16,9 @@ parameters:
         image: appuio/machine-api-provider-cloudscale
         tag: v0.2.5
       kube_rbac_proxy:
-        registry: gcr.io
-        image: kubebuilder/kube-rbac-proxy
-        tag: v0.16.0
+        registry: quay.io
+        image: brancz/kube-rbac-proxy
+        tag: v0.18.2
 
     resources:
       provider:

--- a/tests/golden/defaults/machine-api-provider-cloudscale/machine-api-provider-cloudscale/11_deployment.yaml
+++ b/tests/golden/defaults/machine-api-provider-cloudscale/machine-api-provider-cloudscale/11_deployment.yaml
@@ -96,7 +96,7 @@ spec:
             - --upstream=http://localhost:8080
             - --logtostderr=true
             - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.18.2
           imagePullPolicy: IfNotPresent
           name: kube-rbac-proxy-manager-metrics
           ports:
@@ -114,7 +114,7 @@ spec:
             - --upstream=http://localhost:8082
             - --logtostderr=true
             - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.18.2
           imagePullPolicy: IfNotPresent
           name: kube-rbac-proxy-mac-metrics
           ports:


### PR DESCRIPTION
`gcr.io` is deprecated and will be removed https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
